### PR TITLE
Add button for user to undo adding the previous food item

### DIFF
--- a/frontend/app/build.gradle
+++ b/frontend/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.2'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test:core-ktx:1.4.0'

--- a/frontend/app/src/main/java/com/cs222/nutrify/ui/NutritionInputFragment.kt
+++ b/frontend/app/src/main/java/com/cs222/nutrify/ui/NutritionInputFragment.kt
@@ -68,6 +68,15 @@ class NutritionInputFragment : Fragment() {
         binding.goToUserPreferencesFromInput.setOnClickListener {
             Navigation.findNavController(it).navigate(R.id.updateUserPreferencesAction)
         }
+
+        binding.undoPreviousNutritionInfo.setOnClickListener {
+            if (viewModel.getNutritionInformationList().isEmpty()) {
+                Toast.makeText(activity, R.string.no_previous_items_exist, Toast.LENGTH_SHORT).show()
+            } else {
+                viewModel.undoPreviousAddition()
+                Toast.makeText(activity, R.string.previous_item_exists, Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     private fun setCalorieObservers() {

--- a/frontend/app/src/main/java/com/cs222/nutrify/viewmodels/NutritionInputViewModel.kt
+++ b/frontend/app/src/main/java/com/cs222/nutrify/viewmodels/NutritionInputViewModel.kt
@@ -61,5 +61,18 @@ class NutritionInputViewModel : ViewModel() {
         nutritionInformationList.add(nutritionInformation)
     }
 
+    fun undoPreviousAddition() {
+        val previousInfo: NutritionInformation = nutritionInformationList.removeLast()
+        calories.value = previousInfo.calories.toString()
+        fat.value = previousInfo.fat.toString()
+        sodium.value = previousInfo.sodium.toString()
+        carbs.value = previousInfo.carbs.toString()
+        sugar.value = previousInfo.sugar.toString()
+        protein.value = previousInfo.protein.toString()
+        calcium.value = previousInfo.calcium.toString()
+        iron.value = previousInfo.iron.toString()
+        potassium.value = previousInfo.potassium.toString()
+    }
+
     fun getNutritionInformationList(): List<NutritionInformation> = nutritionInformationList
 }

--- a/frontend/app/src/main/res/layout/fragment_nutritioninput.xml
+++ b/frontend/app/src/main/res/layout/fragment_nutritioninput.xml
@@ -7,7 +7,7 @@
     <ScrollView
         android:id="@+id/scroll"
         android:layout_width="300dp"
-        android:layout_height="300dp"
+        android:layout_height="200dp"
         android:layout_marginTop="30dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -106,6 +106,16 @@
         app:layout_constraintTop_toBottomOf="@+id/scroll" />
 
     <Button
+        android:id="@+id/undoPreviousNutritionInfo"
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:text="@string/undo_previous_addition"
+        android:layout_marginTop="25dp"
+        app:layout_constraintTop_toBottomOf="@+id/addNutritionInfo"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
         android:id="@+id/submit"
         android:layout_width="wrap_content"
         android:layout_height="50dp"
@@ -113,7 +123,7 @@
         android:layout_marginTop="25dp"
         app:layout_constraintStart_toEndOf="@id/go_to_user_preferences_from_input"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/addNutritionInfo"/>
+        app:layout_constraintTop_toBottomOf="@+id/undoPreviousNutritionInfo"/>
 
     <Button
         android:id="@+id/go_to_user_preferences_from_input"
@@ -121,8 +131,9 @@
         android:layout_height="wrap_content"
         android:text="@string/button_to_user_prefs_from_input"
         android:layout_marginTop="25dp"
-        android:layout_marginLeft="50dp"
-        app:layout_constraintTop_toBottomOf="@+id/addNutritionInfo"
+        android:layout_marginLeft="40dp"
+        app:layout_constraintTop_toBottomOf="@+id/undoPreviousNutritionInfo"
         app:layout_constraintStart_toStartOf="parent"/>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -21,6 +21,9 @@
     <string name="prompt_potassium">Potassium</string>
     <string name="submit_nutrition_info">Submit</string>
     <string name="add_food_information">Add Food Item</string>
+    <string name="undo_previous_addition">Undo Previous Food Item</string>
+    <string name="no_previous_items_exist">No previous food item exists</string>
+    <string name="previous_item_exists">Previous information restored for updating</string>
     <string name="unfilled_text_boxes_add">Please fill out all text boxes</string>
     <string name="filled_text_boxes_add">Food information received</string>
     

--- a/frontend/app/src/test/java/com/cs222/nutrify/viewmodels/NutritionInputViewModelTest.kt
+++ b/frontend/app/src/test/java/com/cs222/nutrify/viewmodels/NutritionInputViewModelTest.kt
@@ -1,0 +1,75 @@
+
+package com.cs222.nutrify.viewmodels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.cs222.nutrify.models.NutritionInformation
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NutritionInputViewModelTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: NutritionInputViewModel
+
+    @Before
+    fun setup() {
+        viewModel = NutritionInputViewModel()
+    }
+
+    @Test
+    fun testAddNutritionInformation() {
+        val expectedNutritionInformation = NutritionInformation(
+            1.2, 3.4, 5.6,
+            7.8, 9.11, 12.13, 14.15, 16.17, 18.19
+        )
+        viewModel.calories.value = "1.2"
+        viewModel.fat.value = "3.4"
+        viewModel.sodium.value = "5.6"
+        viewModel.carbs.value = "7.8"
+        viewModel.sugar.value = "9.11"
+        viewModel.protein.value = "12.13"
+        viewModel.calcium.value = "14.15"
+        viewModel.iron.value = "16.17"
+        viewModel.potassium.value = "18.19"
+        viewModel.addNutritionInformation()
+        Assert.assertEquals(1, viewModel.getNutritionInformationList().size)
+        Assert.assertEquals(expectedNutritionInformation, viewModel.getNutritionInformationList()[0])
+    }
+    @Test
+    fun testUndoPrevious() {
+        viewModel.calories.value = "1.2"
+        viewModel.fat.value = "3.4"
+        viewModel.sodium.value = "5.6"
+        viewModel.carbs.value = "7.8"
+        viewModel.sugar.value = "9.11"
+        viewModel.protein.value = "12.13"
+        viewModel.calcium.value = "14.15"
+        viewModel.iron.value = "16.17"
+        viewModel.potassium.value = "18.19"
+        viewModel.addNutritionInformation()
+        // Setting to empty string to imitate what happens when the user submits nutrition info
+        viewModel.calories.value = ""
+        viewModel.fat.value = ""
+        viewModel.sodium.value = ""
+        viewModel.carbs.value = ""
+        viewModel.sugar.value = ""
+        viewModel.protein.value = ""
+        viewModel.calcium.value = ""
+        viewModel.iron.value = ""
+        viewModel.potassium.value = ""
+        viewModel.undoPreviousAddition()
+        Assert.assertTrue(viewModel.getNutritionInformationList().isEmpty())
+        Assert.assertEquals("1.2", viewModel.calories.value)
+        Assert.assertEquals("3.4", viewModel.fat.value)
+        Assert.assertEquals("5.6", viewModel.sodium.value)
+        Assert.assertEquals("7.8", viewModel.carbs.value)
+        Assert.assertEquals("9.11", viewModel.sugar.value)
+        Assert.assertEquals("12.13", viewModel.protein.value)
+        Assert.assertEquals("14.15", viewModel.calcium.value)
+        Assert.assertEquals("16.17", viewModel.iron.value)
+        Assert.assertEquals("18.19", viewModel.potassium.value)
+    }
+}


### PR DESCRIPTION
The user can click the undo button on the previous food item that they have entered. It will remove the item from the current list they have and restore the information that they had entered for that item. When the user clicks the undo when no item currently exists, there will be a message to notify them that there are no food items.

<img width="307" alt="Screen Shot 2022-11-11 at 6 24 18 PM" src="https://user-images.githubusercontent.com/62852410/201447286-9ecbaeee-607c-48c8-bebd-b57e9d4cb3dd.png">
